### PR TITLE
build: update OpenFeature to 2.8.1

### DIFF
--- a/src/FeatBit.OpenFeature.ServerProvider/FeatBit.OpenFeature.ServerProvider.csproj
+++ b/src/FeatBit.OpenFeature.ServerProvider/FeatBit.OpenFeature.ServerProvider.csproj
@@ -38,7 +38,7 @@
   <ItemGroup>
     <PackageReference Include="FeatBit.ServerSdk" Version="1.2.4" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="OpenFeature" Version="2.5.0" />
+    <PackageReference Include="OpenFeature" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/FeatBit.OpenFeature.ServerProvider/JsonConverters.cs
+++ b/src/FeatBit.OpenFeature.ServerProvider/JsonConverters.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using OpenFeature.Model;
@@ -7,17 +6,6 @@ namespace FeatBit.OpenFeature.ServerProvider;
 
 internal static partial class JsonConverters
 {
-    private static readonly OpenFeatureJsonSerializerContext JsonContext = new(
-        new JsonSerializerOptions(JsonSerializerDefaults.Web)
-        {
-            Converters =
-            {
-                new OpenFeatureValueJsonConverter(),
-                new OpenFeatureStructureJsonConverter()
-            }
-        }
-    );
-
     internal static bool TryDeserializeValue(string? json, out Value value)
     {
         if (json is null or "null")
@@ -28,7 +16,7 @@ internal static partial class JsonConverters
 
         try
         {
-            var deserialized = JsonSerializer.Deserialize(json, JsonContext.Value);
+            var deserialized = JsonSerializer.Deserialize(json, OpenFeatureJsonSerializerContext.Default.Value);
             value = deserialized ?? new Value();
             return deserialized is not null;
         }
@@ -41,52 +29,10 @@ internal static partial class JsonConverters
 
     internal static string SerializeValue(Value value)
     {
-        return JsonSerializer.Serialize(value, JsonContext.Value);
-    }
-
-    private sealed class OpenFeatureValueJsonConverter : JsonConverter<Value>
-    {
-        public override Value? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            return reader.TokenType switch
-            {
-                JsonTokenType.StartObject =>
-                    new Value(JsonSerializer.Deserialize<Structure>(ref reader, options)!),
-                JsonTokenType.StartArray =>
-                    new Value(JsonSerializer.Deserialize<IImmutableList<Value>>(ref reader, options)!),
-                JsonTokenType.String => new Value(reader.GetString()!),
-                JsonTokenType.Number => new Value(reader.GetDouble()),
-                JsonTokenType.True => new Value(true),
-                JsonTokenType.False => new Value(false),
-                JsonTokenType.Null => new Value(),
-                _ => null
-            };
-        }
-
-        public override void Write(Utf8JsonWriter writer, Value value, JsonSerializerOptions options)
-        {
-            JsonSerializer.Serialize(writer, value.AsObject, options);
-        }
-    }
-
-    private sealed class OpenFeatureStructureJsonConverter : JsonConverter<Structure>
-    {
-        public override Structure? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            var dict = JsonSerializer.Deserialize<IDictionary<string, Value>>(ref reader, options);
-            return dict is null ? null : new Structure(dict);
-        }
-
-        public override void Write(Utf8JsonWriter writer, Structure value, JsonSerializerOptions options)
-        {
-            JsonSerializer.Serialize(writer, value.AsDictionary(), options);
-        }
+        return JsonSerializer.Serialize(value, OpenFeatureJsonSerializerContext.Default.Value);
     }
 
     [JsonSerializable(typeof(Value))]
-    [JsonSerializable(typeof(Structure))]
-    [JsonSerializable(typeof(IDictionary<string, Value>))]
-    [JsonSerializable(typeof(IImmutableDictionary<string, Value>))]
     private partial class OpenFeatureJsonSerializerContext : JsonSerializerContext
     {
     }


### PR DESCRIPTION
Replace the custom JsonConverters with the JsonConverter added in OpenFeature 2.8.1.

This is required for compatibility with OpenFeature 2.8.0 and higher.